### PR TITLE
Add charts and tweak hero layout

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -129,17 +129,17 @@
             </div>
         </section>
 
-        <!-- Gallery Section -->
-        <section class="gallery-section">
+        <!-- Interactive Charts -->
+        <section id="charts" class="gallery-section">
             <div class="container">
                 <h2 class="text-center">Your Growth in Real Time</h2>
                 <div class="gallery-grid">
-                    <div class="placeholder-img chart"><span>GGR Chart</span></div>
-                    <div class="placeholder-img chart"><span>LTV Analytics</span></div>
-                    <div class="placeholder-img chart"><span>MAU Growth</span></div>
-                    <div class="placeholder-img chart"><span>Campaign ROI</span></div>
-                    <div class="placeholder-img chart"><span>Financial Report</span></div>
-                    <div class="placeholder-img chart"><span>Player Activity</span></div>
+                    <div class="chart-container"><canvas id="ggrChart"></canvas></div>
+                    <div class="chart-container"><canvas id="ltvChart"></canvas></div>
+                    <div class="chart-container"><canvas id="mauChart"></canvas></div>
+                    <div class="chart-container"><canvas id="roiChart"></canvas></div>
+                    <div class="chart-container"><canvas id="dauChart"></canvas></div>
+                    <div class="chart-container"><canvas id="depositsChart"></canvas></div>
                 </div>
             </div>
         </section>
@@ -397,6 +397,8 @@
     
     <!-- SwiperJS -->
     <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <!-- Chart.js for interactive graphs -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -129,17 +129,17 @@
             </div>
         </section>
 
-        <!-- Блок картинок с графиками -->
-        <section class="gallery-section">
+        <!-- Интерактивные графики -->
+        <section id="charts" class="gallery-section">
             <div class="container">
                 <h2 class="text-center">Ваш рост в реальном времени</h2>
                 <div class="gallery-grid">
-                    <div class="placeholder-img chart"><span>График GGR</span></div>
-                    <div class="placeholder-img chart"><span>Аналитика LTV</span></div>
-                    <div class="placeholder-img chart"><span>Рост MAU</span></div>
-                    <div class="placeholder-img chart"><span>ROI по кампаниям</span></div>
-                    <div class="placeholder-img chart"><span>Финансовый отчет</span></div>
-                    <div class="placeholder-img chart"><span>Активность игроков</span></div>
+                    <div class="chart-container"><canvas id="ggrChart"></canvas></div>
+                    <div class="chart-container"><canvas id="ltvChart"></canvas></div>
+                    <div class="chart-container"><canvas id="mauChart"></canvas></div>
+                    <div class="chart-container"><canvas id="roiChart"></canvas></div>
+                    <div class="chart-container"><canvas id="dauChart"></canvas></div>
+                    <div class="chart-container"><canvas id="depositsChart"></canvas></div>
                 </div>
             </div>
         </section>
@@ -397,6 +397,8 @@
 
     <!-- SwiperJS -->
     <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <!-- Chart.js for interactive graphs -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -138,6 +138,13 @@ document.addEventListener('DOMContentLoaded', function() {
         };
         
         const labels = ['Янв', 'Фев', 'Мар', 'Апр', 'Май', 'Июн'];
+        const pointStyle = {
+            pointBackgroundColor: '#ffffff',
+            pointBorderWidth: 2,
+            pointRadius: 5,
+            pointHoverRadius: 7,
+            pointHoverBorderWidth: 2
+        };
 
         // GGR Chart
         new Chart(document.getElementById('ggrChart'), {
@@ -150,7 +157,10 @@ document.addEventListener('DOMContentLoaded', function() {
                     borderColor: 'rgb(0, 255, 171)',
                     backgroundColor: 'rgba(0, 255, 171, 0.1)',
                     fill: true,
-                    tension: 0.4
+                    tension: 0.4,
+                    ...pointStyle,
+                    pointBorderColor: 'rgb(0, 255, 171)',
+                    pointHoverBackgroundColor: 'rgb(0, 255, 171)'
                 }]
             },
             options: commonOptions
@@ -167,7 +177,10 @@ document.addEventListener('DOMContentLoaded', function() {
                     borderColor: 'rgb(123, 44, 191)',
                     backgroundColor: 'rgba(123, 44, 191, 0.1)',
                     fill: true,
-                    tension: 0.4
+                    tension: 0.4,
+                    ...pointStyle,
+                    pointBorderColor: 'rgb(123, 44, 191)',
+                    pointHoverBackgroundColor: 'rgb(123, 44, 191)'
                 }]
             },
             options: commonOptions
@@ -183,7 +196,8 @@ document.addEventListener('DOMContentLoaded', function() {
                     data: [12500, 14000, 18000, 21000, 25000, 28000],
                     backgroundColor: 'rgba(0, 255, 171, 0.6)',
                     borderColor: 'rgb(0, 255, 171)',
-                    borderWidth: 1
+                    borderWidth: 1,
+                    hoverBackgroundColor: 'rgba(0, 255, 171, 0.8)'
                 }]
             },
             options: commonOptions
@@ -198,8 +212,9 @@ document.addEventListener('DOMContentLoaded', function() {
                     label: 'ROI',
                     data: [150, 220, 180, 250, 310],
                     borderColor: 'rgb(123, 44, 191)',
-                    pointBackgroundColor: '#fff',
-                    pointRadius: 5
+                    ...pointStyle,
+                    pointBorderColor: 'rgb(123, 44, 191)',
+                    pointHoverBackgroundColor: 'rgb(123, 44, 191)'
                 }]
             },
             options: commonOptions
@@ -215,7 +230,10 @@ document.addEventListener('DOMContentLoaded', function() {
                     data: [1200, 1300, 1500, 1450, 1800, 2500, 2200],
                     borderColor: 'rgb(0, 255, 171)',
                     backgroundColor: 'rgba(0, 255, 171, 0.1)',
-                    fill: true
+                    fill: true,
+                    ...pointStyle,
+                    pointBorderColor: 'rgb(0, 255, 171)',
+                    pointHoverBackgroundColor: 'rgb(0, 255, 171)'
                 }]
             },
             options: commonOptions
@@ -231,7 +249,8 @@ document.addEventListener('DOMContentLoaded', function() {
                     data: [450, 500, 620, 580, 710, 850],
                     backgroundColor: 'rgba(123, 44, 191, 0.6)',
                     borderColor: 'rgb(123, 44, 191)',
-                    borderWidth: 1
+                    borderWidth: 1,
+                    hoverBackgroundColor: 'rgba(123, 44, 191, 0.8)'
                 }]
             },
             options: commonOptions

--- a/styles.css
+++ b/styles.css
@@ -183,14 +183,14 @@ h4 { font-size: 22px; margin-bottom: 10px; }
     gap: 40px;
 }
 .hero-content {
-    flex: 1;
+    flex: 1.4;
 }
 .hero-content .subtitle {
     font-size: 20px;
     margin: 20px 0 30px 0;
 }
 .hero-visuals {
-    flex: 1;
+    flex: 0.8;
     display: flex;
     justify-content: center;
     position: relative;
@@ -324,12 +324,18 @@ h4 { font-size: 22px; margin-bottom: 10px; }
     color: var(--text-dark-color);
     border: 1px dashed var(--border-color);
 }
-.placeholder-img.chart {
-    background-image: 
-        linear-gradient(rgba(0, 255, 171, 0.1) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(0, 255, 171, 0.1) 1px, transparent 1px);
-    background-size: 20px 20px;
-    border-color: var(--green-color);
+.chart-container {
+    background: var(--secondary-color);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    min-height: 250px;
+    padding: 15px;
+    position: relative;
+}
+
+.chart-container canvas {
+    width: 100%;
+    height: 100%;
 }
 
 /* --- TOOLS --- */


### PR DESCRIPTION
## Summary
- widen hero section content area
- replace image placeholders with Chart.js canvases
- load Chart.js and update script for interactive charts
- style chart containers

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e00222e10832baedccf9a149119b6