### PR TITLE
Improve desktop buttons and chart translations

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,10 +6,19 @@ document.addEventListener('DOMContentLoaded', function() {
         // 1. Анімація логотипа в шапці
         const slotMachine = document.querySelector('.logo .slot-machine');
         if (slotMachine && !slotMachine.hasAttribute('data-animated')) {
-            setInterval(() => {
-                slotMachine.classList.add('spin');
-                setTimeout(() => slotMachine.classList.remove('spin'), 1000);
-            }, 10000);
+            const digits = slotMachine.querySelectorAll('span');
+
+            function spinOnce() {
+                digits.forEach((d, i) => {
+                    setTimeout(() => {
+                        d.classList.add('spin');
+                        setTimeout(() => d.classList.remove('spin'), 600);
+                    }, i * 200);
+                });
+            }
+
+            spinOnce();
+            setInterval(spinOnce, 10000);
             slotMachine.setAttribute('data-animated', 'true');
         }
         
@@ -137,7 +146,18 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         };
         
-        const labels = ['Янв', 'Фев', 'Мар', 'Апр', 'Май', 'Июн'];
+        const langCode = document.documentElement.lang || 'ru';
+        const monthLabels = langCode === 'ru'
+            ? ['Янв', 'Фев', 'Мар', 'Апр', 'Май', 'Июн']
+            : ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];
+        const campaignLabels = langCode === 'ru'
+            ? ['Камп. 1', 'Камп. 2', 'Камп. 3', 'Камп. 4', 'Камп. 5']
+            : ['Campaign 1', 'Campaign 2', 'Campaign 3', 'Campaign 4', 'Campaign 5'];
+        const dayLabels = langCode === 'ru'
+            ? ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс']
+            : ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+        const labels = monthLabels;
+        const depositsLabel = langCode === 'ru' ? 'Количество депозитов' : 'Deposits Count';
         const pointStyle = {
             pointBackgroundColor: '#ffffff',
             pointBorderWidth: 2,
@@ -207,7 +227,7 @@ document.addEventListener('DOMContentLoaded', function() {
         new Chart(document.getElementById('roiChart'), {
             type: 'line',
             data: {
-                labels: ['Камп. 1', 'Камп. 2', 'Камп. 3', 'Камп. 4', 'Камп. 5'],
+                labels: campaignLabels,
                 datasets: [{
                     label: 'ROI',
                     data: [150, 220, 180, 250, 310],
@@ -224,7 +244,7 @@ document.addEventListener('DOMContentLoaded', function() {
         new Chart(document.getElementById('dauChart'), {
             type: 'line',
             data: {
-                labels: ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'],
+                labels: dayLabels,
                 datasets: [{
                     label: 'DAU',
                     data: [1200, 1300, 1500, 1450, 1800, 2500, 2200],
@@ -245,7 +265,7 @@ document.addEventListener('DOMContentLoaded', function() {
             data: {
                 labels: labels,
                 datasets: [{
-                    label: 'Deposits Count',
+                    label: depositsLabel,
                     data: [450, 500, 620, 580, 710, 850],
                     backgroundColor: 'rgba(123, 44, 191, 0.6)',
                     borderColor: 'rgb(123, 44, 191)',

--- a/styles.css
+++ b/styles.css
@@ -29,7 +29,7 @@ body {
 
 .container {
     width: 90%;
-    max-width: 1200px;
+    max-width: 1400px;
     margin: 0 auto;
 }
 
@@ -72,13 +72,14 @@ body {
     color: var(--green-color);
     text-shadow: 0 0 5px var(--green-color);
 }
-.slot-machine.spin span {
-    animation: slot-spin 0.2s linear infinite;
+
+.slot-machine span.spin {
+    animation: slot-spin 0.6s ease-in-out;
 }
 
 @keyframes slot-spin {
-    from { transform: translateY(-20px); }
-    to { transform: translateY(20px); }
+    from { transform: rotateX(0deg); }
+    to { transform: rotateX(360deg); }
 }
 
 
@@ -119,6 +120,7 @@ body {
     transition: all 0.3s ease;
     border: none;
     cursor: pointer;
+    white-space: nowrap;
 }
 .btn-primary {
     background-color: transparent;
@@ -331,6 +333,12 @@ h4 { font-size: 22px; margin-bottom: 10px; }
     min-height: 250px;
     padding: 15px;
     position: relative;
+    transition: transform 0.3s;
+}
+
+.chart-container:hover {
+    transform: scale(1.05);
+    z-index: 2;
 }
 
 .chart-container canvas {


### PR DESCRIPTION
## Summary
- tweak container max width for desktop
- prevent button text wrapping
- add hover scale effect for charts
- animate slot machine digits sequentially
- localize chart labels based on page language

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ecfa445b4832b89fe0cfaba29043f